### PR TITLE
changed iOS recordings folder to app's Documents folder due to prepareToRecord failing and to follow Apple guidelines

### DIFF
--- a/src/ios/AudioRecorderAPI.m
+++ b/src/ios/AudioRecorderAPI.m
@@ -3,7 +3,7 @@
 
 @implementation AudioRecorderAPI
 
-#define RECORDINGS_FOLDER [NSHomeDirectory() stringByAppendingPathComponent:@"Library/NoCloud"]
+#define RECORDINGS_FOLDER [NSHomeDirectory() stringByAppendingPathComponent:@"Documents"]
 
 - (void)record:(CDVInvokedUrlCommand*)command {
   _command = command;


### PR DESCRIPTION
…brary/NoCloud. This is for 2 reasons:

```
    1) as recommended by Apple, the Documents folder is used to store user generated content.
    2) [recorder prepareToRecord] fails because the Library/NoCloud directory does not exist by default
```
