### PR TITLE
Android Marshmallow, continuos record, ios documents

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -27,6 +27,9 @@
         <param name="ios-package" value="AudioRecorderAPI"/>
       </feature>
     </config-file>
+    <config-file target="*-Info.plist" parent="NSMicrophoneUsageDescription">
+        <string>Microhphone is needed to record dications</string>
+    </config-file>
     <header-file src="src/ios/AudioRecorderAPI.h"/>
     <source-file src="src/ios/AudioRecorderAPI.m"/>
   </platform>

--- a/src/android/com/emj365/plugins/AudioRecorderAPI.java
+++ b/src/android/com/emj365/plugins/AudioRecorderAPI.java
@@ -114,9 +114,9 @@ public class AudioRecorderAPI extends CordovaPlugin {
     myRecorder.setAudioSource(MediaRecorder.AudioSource.MIC);
     myRecorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
     myRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
-    myRecorder.setAudioSamplingRate(44100);
+    myRecorder.setAudioSamplingRate(8000.0);
     myRecorder.setAudioChannels(1);
-    myRecorder.setAudioEncodingBitRate(32000);
+    myRecorder.setAudioEncodingBitRate(12000);
     myRecorder.setOutputFile(outputFile);
 
     try {

--- a/src/android/com/emj365/plugins/AudioRecorderAPI.java
+++ b/src/android/com/emj365/plugins/AudioRecorderAPI.java
@@ -114,7 +114,7 @@ public class AudioRecorderAPI extends CordovaPlugin {
     myRecorder.setAudioSource(MediaRecorder.AudioSource.MIC);
     myRecorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
     myRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
-    myRecorder.setAudioSamplingRate(8000.0);
+    myRecorder.setAudioSamplingRate(8000);
     myRecorder.setAudioChannels(1);
     myRecorder.setAudioEncodingBitRate(12000);
     myRecorder.setOutputFile(outputFile);

--- a/src/android/com/emj365/plugins/AudioRecorderAPI.java
+++ b/src/android/com/emj365/plugins/AudioRecorderAPI.java
@@ -11,62 +11,51 @@ import android.media.AudioManager;
 import android.os.CountDownTimer;
 import android.os.Environment;
 import android.content.Context;
+import android.content.pm.PackageManager;
+import android.Manifest;
 import java.util.UUID;
 import java.io.FileInputStream;
 import java.io.File;
 import java.io.IOException;
 
 public class AudioRecorderAPI extends CordovaPlugin {
+  private static final String RECORD = Manifest.permission.RECORD_AUDIO;
+  private static final int AUDIO_RECORD_PERMISSION_CALLBACK = 0;
 
   private MediaRecorder myRecorder;
   private String outputFile;
   private CountDownTimer countDowntimer;
 
+  private CallbackContext callbackContext;
+  private Integer seconds;
+
   @Override
   public boolean execute(String action, JSONArray args, final CallbackContext callbackContext) throws JSONException {
     Context context = cordova.getActivity().getApplicationContext();
-    Integer seconds;
+
     if (args.length() >= 1) {
       seconds = args.getInt(0);
     } else {
-      seconds = 7;
+      seconds = -1;
     }
     if (action.equals("record")) {
-      outputFile = context.getFilesDir().getAbsoluteFile() + "/"
-        + UUID.randomUUID().toString() + ".m4a";
-      myRecorder = new MediaRecorder();
-      myRecorder.setAudioSource(MediaRecorder.AudioSource.MIC);
-      myRecorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
-      myRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
-      myRecorder.setAudioSamplingRate(44100);
-      myRecorder.setAudioChannels(1);
-      myRecorder.setAudioEncodingBitRate(32000);
-      myRecorder.setOutputFile(outputFile);
+      this.callbackContext = callbackContext;
 
-      try {
-        myRecorder.prepare();
-        myRecorder.start();
-      } catch (final Exception e) {
-        cordova.getThreadPool().execute(new Runnable() {
-          public void run() {
-            callbackContext.error(e.getMessage());
-          }
-        });
-        return false;
+      if (!cordova.hasPermission(RECORD)) {
+        cordova.requestPermission(this, AUDIO_RECORD_PERMISSION_CALLBACK, RECORD);
+
+        return true;
       }
-
-      countDowntimer = new CountDownTimer(seconds * 1000, 1000) {
-        public void onTick(long millisUntilFinished) {}
-        public void onFinish() {
-          stopRecord(callbackContext);
-        }
-      };
-      countDowntimer.start();
-      return true;
+      else {
+        return record(context);
+      }
     }
 
     if (action.equals("stop")) {
-      countDowntimer.cancel();
+      if (countDowntimer != null) {
+        countDowntimer.cancel();
+        countDowntimer = null;
+      }
       stopRecord(callbackContext);
       return true;
     }
@@ -103,6 +92,54 @@ public class AudioRecorderAPI extends CordovaPlugin {
     }
 
     return false;
+  }
+
+  public void onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults) throws JSONException {
+    for (int r: grantResults){
+      if (r == PackageManager.PERMISSION_DENIED) {
+        this.callbackContext.error("Permission was denied");
+      }
+
+      switch(requestCode) {
+        case AUDIO_RECORD_PERMISSION_CALLBACK:
+          this.record(cordova.getActivity().getApplicationContext());
+          break;
+      }
+    }
+  }
+
+  private boolean record(Context context) {
+    outputFile = context.getFilesDir().getAbsoluteFile() + "/" + UUID.randomUUID().toString() + ".m4a";
+    myRecorder = new MediaRecorder();
+    myRecorder.setAudioSource(MediaRecorder.AudioSource.MIC);
+    myRecorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
+    myRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
+    myRecorder.setAudioSamplingRate(44100);
+    myRecorder.setAudioChannels(1);
+    myRecorder.setAudioEncodingBitRate(32000);
+    myRecorder.setOutputFile(outputFile);
+
+    try {
+      myRecorder.prepare();
+      myRecorder.start();
+    } catch (final Exception e) {
+      cordova.getThreadPool().execute(new Runnable() {
+        public void run() {
+          callbackContext.error(e.getMessage());
+        }
+      });
+      return false;
+    }
+    if (seconds != -1) {
+      countDowntimer = new CountDownTimer(seconds * 1000, 1000) {
+        public void onTick(long millisUntilFinished) {}
+        public void onFinish() {
+          stopRecord(callbackContext);
+        }
+      };
+      countDowntimer.start();
+    }
+    return true;
   }
 
   private void stopRecord(final CallbackContext callbackContext) {

--- a/src/ios/AudioRecorderAPI.m
+++ b/src/ios/AudioRecorderAPI.m
@@ -3,7 +3,7 @@
 
 @implementation AudioRecorderAPI
 
-#define RECORDINGS_FOLDER [NSHomeDirectory() stringByAppendingPathComponent:@"Library/NoCloud"]
+#define RECORDINGS_FOLDER [NSHomeDirectory() stringByAppendingPathComponent:@"Documents"]
 
 - (void)record:(CDVInvokedUrlCommand*)command {
   _command = command;

--- a/src/ios/AudioRecorderAPI.m
+++ b/src/ios/AudioRecorderAPI.m
@@ -37,7 +37,7 @@
     [recordSettings setObject:[NSNumber numberWithInt:1] forKey:AVNumberOfChannelsKey];
     [recordSettings setObject:[NSNumber numberWithInt:12000] forKey:AVEncoderBitRateKey];
     [recordSettings setObject:[NSNumber numberWithInt:8] forKey:AVLinearPCMBitDepthKey];
-    [recordSettings setObject:[NSNumber numberWithInt: AVAudioQualityLow] forKey: AVEncoderAudioQualityKey];
+    [recordSettings setObject:[NSNumber numberWithInt: AVAudioQualityMedium] forKey: AVEncoderAudioQualityKey];
 
     // Create a new dated file
     NSString *uuid = [[NSUUID UUID] UUIDString];

--- a/src/ios/AudioRecorderAPI.m
+++ b/src/ios/AudioRecorderAPI.m
@@ -7,7 +7,12 @@
 
 - (void)record:(CDVInvokedUrlCommand*)command {
   _command = command;
-  duration = [_command.arguments objectAtIndex:0];
+  if ([_command.arguments count] > 0) {
+    duration = [_command.arguments objectAtIndex:0];
+  }
+  else {
+    duration = nil;
+  }
 
   [self.commandDelegate runInBackground:^{
 
@@ -53,10 +58,17 @@
       NSLog(@"prepareToRecord failed");
       return;
     }
-
-    if (![recorder recordForDuration:(NSTimeInterval)[duration intValue]]) {
-      NSLog(@"recordForDuration failed");
-      return;
+    if (duration == nil || duration.integerValue == -1) {
+      if (![recorder record]) {
+        NSLog(@"record failed");
+        return;
+      }
+    }
+    else {
+      if (![recorder recordForDuration:(NSTimeInterval)[duration intValue]]) {
+        NSLog(@"recordForDuration failed");
+        return;
+      }
     }
 
   }];
@@ -107,3 +119,4 @@
 }
 
 @end
+


### PR DESCRIPTION
On newer versions of android and iOS your plugin does not work.

This fixes:
  - Android permissions (it will now prompt for audio permission when you try to record
  - iOS filepath nolonger works

And additionally, I made it so you don't have to specify a duration.  That seems useless to me in most cases, I just want to record continuously.  (Though obviously, if you specify a duration, it will work still as before)